### PR TITLE
Fix double-invocation of plugin

### DIFF
--- a/plugin/indent-o-matic.vim
+++ b/plugin/indent-o-matic.vim
@@ -1,4 +1,4 @@
-command IndentOMatic execute "lua require('indent-o-matic').detect()"
+command! IndentOMatic execute "lua require('indent-o-matic').detect()"
 
 augroup indent_o_matic
     au!


### PR DESCRIPTION
Sometimes plugin/ files can be called twice:

<img width="1082" alt="image" src="https://user-images.githubusercontent.com/74385/165407222-380ec840-f540-4ff9-9111-2f1885fc60bd.png">

This should make it okay to do so.