### PR TITLE
Seventh release! (Adding `skip_multiline`, fixes #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ require('indent-o-matic').setup {
 
     -- Space indentations that should be detected
     standard_widths = { 2, 4, 8 },
+
+    -- Skip multi-line comments and strings (more accurate detection but less performant)
+    skip_multiline = true,
 }
 ```
 

--- a/lua/indent-o-matic.lua
+++ b/lua/indent-o-matic.lua
@@ -108,15 +108,15 @@ function indent_o_matic.detect()
             goto continue
         end
 
-        -- Skip multi-line comments and strings (1-indexed)
-        if skip_multiline and is_multiline(i + 1) then
-            goto continue
-        end
-
         -- If a line starts with a tab then the file must be tab indented
         -- else if it starts with spaces it tries to detect if it's the file's indentation
         first_char = line:sub(1, 1)
         if first_char == '\t' then
+            -- Skip multi-line comments and strings (1-indexed)
+            if skip_multiline and is_multiline(i + 1) then
+                goto continue
+            end
+
             detected = 0
             break
         elseif first_char == ' ' then
@@ -137,6 +137,11 @@ function indent_o_matic.detect()
             -- If it's a standard number of spaces it's probably the file's indentation
             j = j - 1
             if contains(standard_widths, j) then
+                -- Skip multi-line comments and strings (1-indexed)
+                if skip_multiline and is_multiline(i + 1) then
+                    goto continue
+                end
+
                 detected = j
                 break
             end

--- a/lua/indent-o-matic.lua
+++ b/lua/indent-o-matic.lua
@@ -63,7 +63,7 @@ local function get_default_indent()
 end
 
 -- Detect if the line is a comment or a string
-local function should_be_skipped(line_number)
+local function is_multiline(line_number)
     -- Originally taken from leisiji's code:
     -- https://github.com/leisiji/indent-o-matic/blob/c440898e3e6bcc12c9c24d4867875712c4d1b5f7/lua/indent-o-matic.lua#L51-L57
     local syntax = vim.fn.synIDattr(vim.fn.synIDtrans(vim.fn.synID(line_number, 1, 1)), 'name')
@@ -89,6 +89,7 @@ function indent_o_matic.detect()
     -- Options
     local max_lines = config('max_lines', 2048)
     local standard_widths = config('standard_widths', { 2, 4, 8 })
+    local skip_multiline = config('skip_multiline', true)
 
     -- Loop over every line, breaking once it finds something that looks like a
     -- standard indentation or if it reaches end of file
@@ -108,7 +109,7 @@ function indent_o_matic.detect()
         end
 
         -- Skip multi-line comments and strings (1-indexed)
-        if should_be_skipped(i + 1) then
+        if skip_multiline and is_multiline(i + 1) then
             goto continue
         end
 

--- a/lua/indent-o-matic.lua
+++ b/lua/indent-o-matic.lua
@@ -62,6 +62,14 @@ local function get_default_indent()
     end
 end
 
+-- Detect if the line is a comment or a string
+local function should_be_skipped(line_number)
+    -- Originally taken from leisiji's code:
+    -- https://github.com/leisiji/indent-o-matic/blob/c440898e3e6bcc12c9c24d4867875712c4d1b5f7/lua/indent-o-matic.lua#L51-L57
+    local syntax = vim.fn.synIDattr(vim.fn.synIDtrans(vim.fn.synID(line_number, 1, 1)), 'name')
+    return syntax == "Comment" or syntax == "String"
+end
+
 -- Configure the plugin
 function indent_o_matic.setup(options)
     if type(options) == 'table' then
@@ -96,6 +104,11 @@ function indent_o_matic.detect()
 
         -- Skip empty lines
         if #line == 0 then
+            goto continue
+        end
+
+        -- Skip multi-line comments and strings (1-indexed)
+        if should_be_skipped(i + 1) then
             goto continue
         end
 


### PR DESCRIPTION
New :

- `skip_multiline` can be set to enable/disable skipping multi-line comments and strings