### PR TITLE
fix: check if buffer line table is empty before getting the line size

### DIFF
--- a/lua/indent-o-matic.lua
+++ b/lua/indent-o-matic.lua
@@ -163,7 +163,7 @@ function M.detect()
         local first_char
 
         local ok, line = pcall(function() return line_at(i) end)
-        if not ok then
+        if not ok or line == nil then
             -- End of file
             break
         end


### PR DESCRIPTION
If a buffer has no lines, vim.api.get_buf_get_lines() will return an empty table. Attempting to index into the table will return a nil value.

Change the function detect() to verify if the buffer line table is empty before trying to use its first indexed value.