### PR TITLE
fix(indent-o-matic): better `autocmds` for new files

### DIFF
--- a/plugin/indent-o-matic.vim
+++ b/plugin/indent-o-matic.vim
@@ -4,5 +4,5 @@ augroup indent_o_matic
     au!
     au BufReadPost * IndentOMatic
     " Run once when saving for new files
-    au BufNew * au BufWritePost <buffer=abuf> ++once IndentOMatic
+    au BufNewFile,BufAdd * au BufWritePost <buffer=abuf> ++once IndentOMatic
 augroup END


### PR DESCRIPTION
Hi! @Darazaki - This small contribution is to replace the `autocmd` for new files with the most optimal ones.

Signed-off-by: Wuelner Martínez <wuelner.martinez@outlook.com>